### PR TITLE
Add docs for crud-field readonly option

### DIFF
--- a/docs/super-scaffolding.md
+++ b/docs/super-scaffolding.md
@@ -108,6 +108,11 @@ rake db:migrate
 
 As you can see, when we're using `crud-field`, we don't need to supply the chain of ownership back to `Team`.
 
+If you want to scaffold a new field to use for read-only purposes, add the following option to omit the field from the form and all other files that apply:
+```
+bin/super-scaffold crud-field Project description:trix_editor{readonly}
+```
+
 ### 4. Adding Option Fields with Fixed, Translatable Options
 
 Continuing with the earlier example, let's address the following new requirement:


### PR DESCRIPTION
These are the docs for the feature that closes [this issue](https://github.com/bullet-train-co/bullet_train-super_scaffolding/issues/15).

I'm not sure if adding `readonly` to `trix_editor` here is ideal, but I wanted to stay consistent with the example we use in `crud-field`. I'll update it with something else if using something like `text_field` makes more sense.