### PR TITLE
Start adding Tailwind to mailer layout

### DIFF
--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -4,6 +4,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title>Welcome to <%= t('application.name') %>!</title>
+
+
+
     <% # TODO This is not what we want to do long-term. Would love to see this powered by Tailwind CSS. %>
     <style type="text/css">
       *:not(br):not(tr):not(html) {
@@ -12,13 +15,7 @@
       }
 
       body {
-        width: 100% !important;
-        height: 100%;
-        margin: 0;
-        line-height: 1.4;
-        background-color: #F6F7F8;
         color: #3E4B5B;
-        font-size: 16px;
         -webkit-text-size-adjust: none;
       }
 
@@ -40,27 +37,10 @@
       /* Layout ------------------------------ */
 
       .email-wrapper {
-        width: 100%;
-        margin: 0;
-        padding: 0;
         background-color: #F6F7F8;
       }
 
-      .email-content {
-        width: 100%;
-        margin: 0;
-        padding: 0;
-      }
       /* Masthead ----------------------- */
-
-      .email-masthead {
-        padding: 25px 0;
-        text-align: center;
-      }
-
-      .email-masthead_logo {
-        width: 94px;
-      }
 
       .email-masthead_name {
         font-size: 16px;
@@ -69,6 +49,7 @@
         text-decoration: none;
         /*text-shadow: 0 1px 0 white;*/
       }
+
       /* Body ------------------------------ */
 
       .email-body {
@@ -365,16 +346,16 @@
       }
     </style>
   </head>
-  <body>
+  <body class="w-full h-full m-0 text-base">
     <% if content_for? :preheader %>
     <span class="preheader"><% yield :preheader %></span>
     <% end %>
-    <table class="email-wrapper" width="100%" cellpadding="0" cellspacing="0">
+    <table class="email-wrapper w-full m-0 p-0" cellpadding="0" cellspacing="0">
       <tr>
         <td align="center">
-          <table class="email-content" width="100%" cellpadding="0" cellspacing="0">
+          <table class="email-content w-full m-0 p-0" cellpadding="0" cellspacing="0">
             <tr>
-              <td class="email-masthead">
+              <td class="email-masthead py-6 text-center">
                 <a href="<%= root_url %>" class="email-masthead_name">
                   <%= email_image_tag("logo/logo.png", width: image_width_for_height("logo/logo.png", BulletTrain::Themes.logo_height), height: BulletTrain::Themes.logo_height, style: "width: #{image_width_for_height('logo/logo.png', BulletTrain::Themes.logo_height)}px; height: #{BulletTrain::Themes.logo_height}px;") %>
                 </a>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -5,7 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
     <title>Welcome to <%= t('application.name') %>!</title>
 
-
+    <%= render 'themes/light/layouts/head' %>
 
     <% # TODO This is not what we want to do long-term. Would love to see this powered by Tailwind CSS. %>
     <style type="text/css">


### PR DESCRIPTION
・Addresses the TODO in the mailer layout.

I was able to use Tailwind after adding `<%= render 'themes/light/layouts/head' %>`, but there are still a lot of overrides going on here, so adding Tailwind won't always work. I'd be glad to clean this up, but it looks like I'll have to find out specifically how all the styles are being imported here.

Pinging @jorbs and @pascallaliberte in case you guys have any ideas or if I'm overlooking anything.
