### PR TITLE
Fix sign out logic on user details onboarding page

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,3 +1,14 @@
 class SessionsController < Devise::SessionsController
   include Sessions::ControllerBase
+
+  def destroy
+    if params.include?(:onboard_logout)
+      signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
+      set_flash_message! :notice, :signed_out if signed_out
+      yield if block_given?
+      redirect_to root_path
+    else
+      super
+    end
+  end
 end

--- a/app/views/account/onboarding/user_details/edit.html.erb
+++ b/app/views/account/onboarding/user_details/edit.html.erb
@@ -38,7 +38,7 @@
           <% if other_teams.any? %>
             <%= link_to t('global.buttons.back'), main_app.account_teams_path, class: first_button_primary %>
           <% else %>
-            <%= link_to t('menus.main.labels.logout'), main_app.destroy_user_session_path, class: first_button_primary, method: 'delete' %>
+            <%= link_to t('menus.main.labels.logout'), main_app.destroy_user_session_path(@user, onboard_logout: true), class: first_button_primary, method: 'delete' %>
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
Fix the [sign out issue from a while back](https://github.com/bullet-train-co/bullet-train-tailwind-css/issues/395) on the onboarding step.

## Unregister the ServiceWorker in Chrome
I wasn't experiencing the same problem in the original issue. This was most likely because I was mainly checking things in Firefox back then, but I’ve been using Chrome mostly now, and I ran into the same issue recently which led me to work on this. 

When first inspecting the issue, I was getting this in my logs:
```
ActionController::RoutingError (No route matches [GET] "/sw.js")
```

Looking into it, I found [this Stack Overflow post](https://stackoverflow.com/questions/56939942/how-to-fix-routingerror-for-a-get-request-looking-for-a-file-sw-js). I also found [this Rails issue](https://github.com/rails/rails/issues/37570) where someone mentions the same SO post, and they also said how they only experienced their issue while using Chrome, but not with Firefox or Safari.

The JavaScript code in the SO post they tell you to run in the console to fix the issue didn’t work for me, so it required more work. 

Following along with the SO post, to unregister the ServiceWorker (sw.js) I opened the dev tools, clicked the Application tab and then clicked Service Workers. I found sw.js there, but there were some links on the right side, one of them being `Unregister`. I wasn’t able to click it (I'm assuming because it was running at the time), so I ended up going to [chrome://serviceworker-internals/?devtools](chrome://serviceworker-internals/?devtools), finding the sw.js worker where the scope was `http://localhost:3000/`, and stopping it first:

![Screenshot from 2022-05-19 21-09-30](https://user-images.githubusercontent.com/10546292/169290058-c670eea3-1f65-4133-9f6b-036c87901156.png)

It says here that it's an unregistered worker, but also that it's running, and it was still showing up in the Application tab of the dev tools. After I clicked the Stop button, the Unregister button showed up and I was able to successfully unregister the ServiceWorker (it disappeared from the dev tools after pressing the button too).

## Devise override
The [original devise `destroy` code](https://github.com/heartcombo/devise/blob/main/app/controllers/devise/sessions_controller.rb) isn’t too long, so this wasn’t too difficult to edit.
```ruby
# From the original devise session controller
def destroy
  signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))
  set_flash_message! :notice, :signed_out if signed_out
  yield if block_given?
  respond_to_on_destroy
end

def respond_to_on_destroy
  # We actually need to hardcode this as Rails default responder doesn't
  # support returning empty response on GET request
  respond_to do |format|
    format.all { head :no_content }
    format.any(*navigational_formats) { redirect_to after_sign_out_path_for(resource_name) }
  end
end
```