### PR TITLE
Clone git repositories in `bin/resolve` with Gitpod

### DIFF
--- a/lib/tasks/bullet_train_tasks.rake
+++ b/lib/tasks/bullet_train_tasks.rake
@@ -170,7 +170,7 @@ namespace :bullet_train do
         # TODO We should also pull `origin/main` to make sure we're on the most up-to-date version of the package.
       else
         # Use https:// URLs when using this task in Gitpod.
-        stream "git clone #{`whoami`.chomp == "gitpod" ? "https://github.com": "git@github.com:"}#{details[:git]}.git local/#{gem}"
+        stream "git clone #{`whoami`.chomp == "gitpod" ? "https://github.com/": "git@github.com:"}#{details[:git]}.git local/#{gem}"
       end
 
       # TODO Ask them whether they want to check out a specific branch to work on. (List available remote branches.)

--- a/lib/tasks/bullet_train_tasks.rake
+++ b/lib/tasks/bullet_train_tasks.rake
@@ -169,7 +169,8 @@ namespace :bullet_train do
         # TODO We should check whether the local copy is in a clean state, and if it is, check out `main`.
         # TODO We should also pull `origin/main` to make sure we're on the most up-to-date version of the package.
       else
-        stream "git clone git@github.com:#{details[:git]}.git local/#{gem}"
+        # Use https:// URLs when using this task in Gitpod.
+        stream "git clone #{`whoami`.chomp == "gitpod" ? "https://github.com": "git@github.com:"}#{details[:git]}.git local/#{gem}"
       end
 
       # TODO Ask them whether they want to check out a specific branch to work on. (List available remote branches.)

--- a/lib/tasks/bullet_train_tasks.rake
+++ b/lib/tasks/bullet_train_tasks.rake
@@ -170,7 +170,7 @@ namespace :bullet_train do
         # TODO We should also pull `origin/main` to make sure we're on the most up-to-date version of the package.
       else
         # Use https:// URLs when using this task in Gitpod.
-        stream "git clone #{`whoami`.chomp == "gitpod" ? "https://github.com/": "git@github.com:"}#{details[:git]}.git local/#{gem}"
+        stream "git clone #{`whoami`.chomp == "gitpod" ? "https://github.com/" : "git@github.com:"}#{details[:git]}.git local/#{gem}"
       end
 
       # TODO Ask them whether they want to check out a specific branch to work on. (List available remote branches.)


### PR DESCRIPTION
Closes [bullet_train#239](https://github.com/bullet-train-co/bullet_train/issues/239)
You can test the Gitpod workspace by putting this link in the browser:
`gitpod.io/#https://github.com/gazayas/bullet_train/tree/features/bin-develop-with-gitpod`

Looks like this:
![Screenshot from 2022-06-23 19-40-00](https://user-images.githubusercontent.com/10546292/175280924-b1279d6a-b777-4aea-b941-ce2149acf62f.png)

