### PR TITLE
Comment out relation to nonexistent model

### DIFF
--- a/app/models/concerns/memberships/base.rb
+++ b/app/models/concerns/memberships/base.rb
@@ -13,7 +13,9 @@ module Memberships::Base
 
     has_many :scaffolding_completely_concrete_tangible_things_assignments, class_name: "Scaffolding::CompletelyConcrete::TangibleThings::Assignment", dependent: :destroy
     has_many :scaffolding_completely_concrete_tangible_things, through: :scaffolding_completely_concrete_tangible_things_assignments, source: :tangible_thing
-    has_many :reassignments_scaffolding_completely_concrete_tangible_things_reassignments, class_name: "Memberships::Reassignments::ScaffoldingCompletelyConcreteTangibleThingsReassignment", dependent: :destroy, foreign_key: :membership_id
+
+    # TODO: Add model, controller, and any other necessary logic to incorporate this class.
+    # has_many :reassignments_scaffolding_completely_concrete_tangible_things_reassignments, class_name: "Memberships::Reassignments::ScaffoldingCompletelyConcreteTangibleThingsReassignment", dependent: :destroy, foreign_key: :membership_id
 
     has_many :scaffolding_absolutely_abstract_creative_concepts_collaborators, class_name: "Scaffolding::AbsolutelyAbstract::CreativeConcepts::Collaborator", dependent: :destroy
 


### PR DESCRIPTION
Addresses (but doesn't fix) [bullet_train#270](https://github.com/bullet-train-co/bullet_train/issues/270)

## Details
Whereas the class `Memberships::Reassignments::ScaffoldingCompletelyConcreteTangibleThingsReassignment` was present under `app/models/membership/reassignments/scaffolding_completely_concrete_tangible_things_reassignment.rb` before the Great Unbundling, it's not present in our current stack. I was able to make a little progress by adding the class in `bullet_train-super_scaffolding`, but couldn't quite link it to the proper database table. However, I'm assuming this is relatively low-priority since we don't have the model in place as of now.

Since the original issue brought up the fact that we can't delete Teams, I commented out the line in `memberships/base.rb` preventing us from doing so and added a TODO here so we know what we need to take care of if we decide to implement this later on. All the tests (including the Super Scaffolding system tests) are passing locally, so we should be fine.

Dropping the [Reassignments database migration](https://github.com/bullet-train-co/bullet_train/blob/main/db/migrate/20200328203304_create_memberships_reassignments_scaffolding_completely_concrete_tangible_things_reassignments.rb) here for reference.