### PR TITLE
Remove TODO comment concerning oauth placeholder emails

### DIFF
--- a/app/models/concerns/users/base.rb
+++ b/app/models/concerns/users/base.rb
@@ -37,9 +37,6 @@ module Users::Base
     after_update :set_teams_time_zone
   end
 
-  # TODO we need to update this to some sort of invalid email address or something
-  # people know to ignore. it would be a security problem to have this pointing
-  # at anybody's real email address.
   def email_is_oauth_placeholder?
     !!email.match(/noreply\+.*@bullettrain.co/)
   end

--- a/app/models/concerns/users/base.rb
+++ b/app/models/concerns/users/base.rb
@@ -38,7 +38,7 @@ module Users::Base
   end
 
   def email_is_oauth_placeholder?
-    !!email.match(/noreply\+.*@bullettrain.co/)
+    !!email.match(/noreply\+.*@bullettrain\.co/)
   end
 
   def label_string


### PR DESCRIPTION
Addresses the TODO in `app/models/concerns/users/base.rb`

## Question
Are we okay to remove this? It looks like this TODO was added way back when in the `A fresh start` commit, and mulling over it I feel like any email that matches `noreply\+.*@bullettrain\.co` should be ok. If I'm missing some context on this one though, I'd be glad to tackle it if the regexp should be changed.

I also went ahead and fixed the regexp so we escape `.` in `.co`.