### PR TITLE
Update new session logic to remember user

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -45,7 +45,7 @@
           <% if devise_mapping.rememberable? %>
             <div class="flex items-center">
               <%= form.check_box :remember_me, class: "h-4 w-4 text-blue focus:ring-blue-dark border-gray-300 rounded" %>
-              <%= form.label :remember_me, class: " ml-2 block" %>
+              <%= form.label :remember_me, class: "ml-2 block" %>
             </div>
           <% end %>
         <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -42,12 +42,12 @@
             <%= form.submit t('global.buttons.sign_in'), class: 'button full' %>
           </div>
 
-          <div class="flex items-center">
-            <input id="remember_me" name="remember_me" type="checkbox" class="h-4 w-4 text-blue focus:ring-blue-dark border-gray-300 rounded">
-            <label for="remember_me" class="ml-2 block">
-              Remember me
-            </label>
-          </div>
+          <% if devise_mapping.rememberable? %>
+            <div class="flex items-center">
+              <%= form.check_box :remember_me, class: "h-4 w-4 text-blue focus:ring-blue-dark border-gray-300 rounded" %>
+              <%= form.label :remember_me, class: " ml-2 block" %>
+            </div>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train/issues/319

Joint PR


## Details
The form logic we had previously wasn't updating the `User` resource, so something like `User.first.remember_created_at` would always yield `nil`.

I looked at the original `sessions/new.html.erb` template when running `rails g devise:view User` and combined it with the Tailwind markup we had, so now the database will get updated with something like this:
![Screenshot from 2022-07-28 10-23-30](https://user-images.githubusercontent.com/10546292/181401506-3cce02f4-e5b3-44d4-b8b2-2749b9756cbe.png)
