### PR TITLE
Use `field_id` in place of `id_for`

### DIFF
--- a/app/helpers/account/forms_helper.rb
+++ b/app/helpers/account/forms_helper.rb
@@ -27,10 +27,6 @@ module Account::FormsHelper
     string.present? ? string : nil
   end
 
-  def id_for(form, method)
-    [form.object.class.name, form.index, method].compact.join("_").underscore
-  end
-
   def model_key(form)
     form.object.class.name.pluralize.underscore
   end


### PR DESCRIPTION
Closes #83.

(Will update with joint PRs soon)

## Details
I mentioned this in the issue as well, but basically we get different output for namespaced models:
```
[1] pry(#<#<Class:0x00007efffc8cfb10>>)> id_for(form, method)
=> "scaffolding/absolutely_abstract/creative_concept_name"
[2] pry(#<#<Class:0x00007efffc8cfb10>>)> form.field_id(method)
=> "scaffolding_absolutely_abstract_creative_concept_name"
```

I'm assuming we'll want to go with the Rails' native strings though, so I'll leave it as is.