### PR TITLE
Update check for oauth placeholder email

### DIFF
--- a/app/models/concerns/users/base.rb
+++ b/app/models/concerns/users/base.rb
@@ -37,11 +37,8 @@ module Users::Base
     after_update :set_teams_time_zone
   end
 
-  # TODO we need to update this to some sort of invalid email address or something
-  # people know to ignore. it would be a security problem to have this pointing
-  # at anybody's real email address.
   def email_is_oauth_placeholder?
-    !!email.match(/noreply\+.*@bullettrain.co/)
+    !!email.match(/noreply@\h{32}\.example\.com/)
   end
 
   def label_string


### PR DESCRIPTION
Closes #84.

I used `\h{32}` here in the regexp to make sure we're getting a 32-character hex value.

Joint PR:
- https://github.com/bullet-train-co/bullet_train-integrations/pull/2