### PR TITLE
Add method to check if model is currently seeding

### DIFF
--- a/app/models/concerns/records/base.rb
+++ b/app/models/concerns/records/base.rb
@@ -1,3 +1,5 @@
+require "rake"
+
 module Records::Base
   extend ActiveSupport::Concern
 
@@ -64,5 +66,13 @@ module Records::Base
     model_name = self.class
     # parent_key = model_name.reflect_on_all_associations(:belongs_to).first.name
     raise "You're trying to use a feature that requires #{model_name} to have a `collection` method defined that returns the Active Record association that this model belongs to within its parent object."
+  end
+
+  def seeding?
+    rake_tasks = ObjectSpace.each_object(Rake::Task)
+    return false if rake_tasks.count.zero?
+
+    db_seed_task = rake_tasks.select {|task| task.name.match?(/^db:seed$/)}.first
+    db_seed_task.already_invoked
   end
 end

--- a/app/models/concerns/records/base.rb
+++ b/app/models/concerns/records/base.rb
@@ -72,7 +72,7 @@ module Records::Base
     rake_tasks = ObjectSpace.each_object(Rake::Task)
     return false if rake_tasks.count.zero?
 
-    db_seed_task = rake_tasks.select {|task| task.name.match?(/^db:seed$/)}.first
+    db_seed_task = rake_tasks.find { |task| task.name.match?(/^db:seed$/) }
     db_seed_task.already_invoked
   end
 end


### PR DESCRIPTION
Closes #90.

Joint PR
- https://github.com/bullet-train-co/bullet_train/pull/339

## Details
We can now put something like the code in the issue to see if a developer is seeding the model or not when running a callback.
