### PR TITLE
Redirect users to their dashboard when access denied

### DIFF
--- a/app/controllers/concerns/controllers/base.rb
+++ b/app/controllers/concerns/controllers/base.rb
@@ -33,8 +33,7 @@ module Controllers::Base
         end
       else
         respond_to do |format|
-          # TODO we do this for now because it ensures `current_team` doesn't remain set in an invalid state.
-          format.html { redirect_to [:account, current_user.teams.first], alert: exception.message }
+          format.html { redirect_to account_teams_url, alert: exception.message }
         end
       end
     end


### PR DESCRIPTION
I thought through this one a bit and as far as I can tell, I don't think we need any other checks to make sure `current_team` is okay.

I wonder if we had this line in place because of how we handled `current_team` in the original `bullet-train`. Either way, I confirmed that `current_team` stays the same after trying to access a restricted page and being redirected to the dashboard.

This new redirect will take the user to their `Team#index` page.