### PR TITLE
Add select-all controller

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,6 +6,7 @@ import ClipboardController from './clipboard_controller'
 import FormController from './form_controller'
 import MobileMenuController from './mobile_menu_controller'
 import TextToggleController from './text_toggle_controller'
+import SelectAllController from './select_all_controller'
 
 export const controllerDefinitions = [
   [BulkActionFormController, 'bulk_action_form_controller.js'],
@@ -14,6 +15,7 @@ export const controllerDefinitions = [
   [FormController, 'form_controller.js'],
   [MobileMenuController, 'mobile_menu_controller.js'],
   [TextToggleController, 'text_toggle_controller.js'],
+  [SelectAllController, 'select_all_controller.js'],
 ].map(function(d) {
   const key = d[1]
   const controller = d[0]

--- a/app/javascript/controllers/select_all_controller.js
+++ b/app/javascript/controllers/select_all_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
     if (!this.hasUnavailableClass) { return }
     
     this.wrapperTarget.classList.remove(this.unavailableClass)
+    this.updateToggle()
   }
   
   selectAllOrNone(event) {

--- a/app/javascript/controllers/select_all_controller.js
+++ b/app/javascript/controllers/select_all_controller.js
@@ -1,0 +1,81 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = [ "checkbox", "toggleCheckbox", "toggleLabel", "wrapper" ]
+  static classes = [ "unavailable" ]
+  
+  connect() {
+    this.enableSelectAll()
+  }
+  
+  enableSelectAll() {
+    if (!this.hasWrapperTarget) { return }
+    if (!this.hasUnavailableClass) { return }
+    
+    this.wrapperTarget.classList.remove(this.unavailableClass)
+  }
+  
+  selectAllOrNone(event) {
+    event.preventDefault()
+    event.stopPropagation()
+    if (this.allSelected) {
+      this.selectNone()
+    } else {
+      this.selectAll()
+    }
+    this.updateToggle()
+    this.dispatch('toggled')
+  }
+  
+  selectAll() {
+    this.checkboxTargets.forEach(checkbox => {
+      checkbox.checked = true
+    })
+  }
+  
+  selectNone() {
+    this.checkboxTargets.forEach(checkbox => {
+      checkbox.checked = false
+    })
+  }
+  
+  updateToggle() {
+    let checkbox = this.toggleCheckboxTarget
+    let useAlternateLabel = false
+    
+    if (this.allSelected) {
+      if (checkbox) {
+        checkbox.checked = true
+        checkbox.indeterminate = false
+      }
+      useAlternateLabel = true
+    } else if (this.selectedValues.length > 0) {
+      if (checkbox) {
+        checkbox.indeterminate = true
+      }
+    } else {
+      if (checkbox) {
+        checkbox.checked = false
+        checkbox.indeterminate = false
+      }
+    }
+    
+    if (this.hasToggleLabelTarget) {
+      this.toggleLabelTarget.dispatchEvent(new CustomEvent(`${this.identifier}:toggle-select-all-label`, { detail: { useAlternate: useAlternateLabel }} ))
+    }
+  }
+  
+  get selectedValues() {
+    let values = []
+    this.checkboxTargets.forEach(checkbox => {
+      if (checkbox.checked) {
+        values.push(checkbox.value)
+      }
+    })
+    return values
+  }
+  
+  get allSelected() {
+    return this.selectedValues.length === this.checkboxTargets.length
+  }
+}


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train-fields/issues/20

Co-dependent PRs:
* https://github.com/bullet-train-co/bullet_train-fields/pull/29
* https://github.com/bullet-train-co/bullet_train-themes-tailwind_css/pull/14

This PR adds a global `select-all` Stimulus controller.

A separate PR will deal with removing the select-all functionality from `bulk-actions`, probably at the same time as we remove it in favour of a new npm package for action-models.