### PR TITLE
Disable Turbo on the sign in form when user_return_to points to an oauth path

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,15 @@
 class SessionsController < Devise::SessionsController
   include Sessions::ControllerBase
 
+  # If user_return_to points to an oauth path we disable Turbo on the sign in form.
+  # This makes it work when we need to redirect to external sites and/or custom protocols.
+  # With Turbo enabled the browser will block those redirects with a CORS error.
+  # https://github.com/bullet-train-co/bullet_train/issues/384
+  def user_return_to_is_oauth
+    session["user_return_to"].match(/^\/oauth/)
+  end
+  helper_method :user_return_to_is_oauth
+
   def destroy
     if params.include?(:onboard_logout)
       signed_out = (Devise.sign_out_all_scopes ? sign_out : sign_out(resource_name))

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < Devise::SessionsController
   # With Turbo enabled the browser will block those redirects with a CORS error.
   # https://github.com/bullet-train-co/bullet_train/issues/384
   def user_return_to_is_oauth
-    session["user_return_to"] && session["user_return_to"].match(/^\/oauth/)
+    session["user_return_to"]&.match(/^\/oauth/)
   end
   helper_method :user_return_to_is_oauth
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -6,7 +6,7 @@ class SessionsController < Devise::SessionsController
   # With Turbo enabled the browser will block those redirects with a CORS error.
   # https://github.com/bullet-train-co/bullet_train/issues/384
   def user_return_to_is_oauth
-    session["user_return_to"].match(/^\/oauth/)
+    session["user_return_to"] && session["user_return_to"].match(/^\/oauth/)
   end
   helper_method :user_return_to_is_oauth
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,7 +2,7 @@
   <% p.content_for :title, t('devise.headers.sign_in') %>
   <% p.content_for :body do %>
     <% within_fields_namespace(:self) do %>
-      <%= form_for resource, as: resource_name, url: two_factor_authentication_enabled? ? users_pre_otp_path : session_path(resource_name), remote: two_factor_authentication_enabled?, html: {class: 'form'}, authenticity_token: true do |form| %>
+      <%= form_for resource, as: resource_name, url: two_factor_authentication_enabled? ? users_pre_otp_path : session_path(resource_name), remote: two_factor_authentication_enabled?, html: {class: 'form'}, authenticity_token: true, data: {turbo: !user_return_to_is_oauth} do |form| %>
         <% with_field_settings form: form do %>
           <%= render 'account/shared/notices', form: form %>
           <%= render 'account/shared/forms/errors', form: form %>


### PR DESCRIPTION
Fixes: https://github.com/bullet-train-co/bullet_train/issues/384

