### PR TITLE
Use `directory_order` in the `Current` class

### DIFF
--- a/app/models/concerns/current_attributes/base.rb
+++ b/app/models/concerns/current_attributes/base.rb
@@ -33,4 +33,9 @@ module CurrentAttributes::Base
       user.memberships.where(team: team)
     end
   end
+
+  def directory_order
+    default_directory_order = BulletTrain::Themes::Light::Theme.new.directory_order
+    default_directory_order.unshift(current_theme.to_s).uniq
+  end
 end

--- a/app/models/concerns/current_attributes/base.rb
+++ b/app/models/concerns/current_attributes/base.rb
@@ -35,7 +35,6 @@ module CurrentAttributes::Base
   end
 
   def directory_order
-    default_directory_order = BulletTrain::Themes::Light::Theme.new.directory_order
-    default_directory_order.unshift(current_theme.to_s).uniq
+    "BulletTrain::Themes::#{current_theme.to_s.capitalize}::Theme".constantize.new.directory_order
   end
 end


### PR DESCRIPTION
Although `directory_order` is available in each `Theme` class, this lets us delegate the method to `Current` in case we want to use it there specifically.

Joint PRs (The main PR is in `bullet_train-themes`)
- https://github.com/bullet-train-co/bullet_train-themes/pull/18
- https://github.com/bullet-train-co/bullet_train/pull/387