### PR TITLE
Add option to disable `devise/pwnd-password`

### DIFF
--- a/app/models/concerns/users/base.rb
+++ b/app/models/concerns/users/base.rb
@@ -9,12 +9,12 @@ module Users::Base
     end
 
     devise :omniauthable
-    devise :pwned_password
     devise :registerable
     devise :recoverable
     devise :rememberable
     devise :trackable
     devise :validatable
+    devise :pwned_password unless disable_pwnd_password?
 
     # teams
     has_many :memberships, dependent: :destroy

--- a/app/views/account/users/edit.html.erb
+++ b/app/views/account/users/edit.html.erb
@@ -32,7 +32,7 @@
               <%= form_for [:account, @user], html: {id: dom_id(@user, :password), class: 'form'} do |form| %>
                 <% with_field_settings form: form do %>
                   <%= render 'shared/fields/password_field', method: :current_password %>
-                  <%= render 'shared/fields/password_field', method: :password, options: {show_strength_indicator: true} %>
+                  <%= render 'shared/fields/password_field', method: :password, options: {show_strength_indicator: !disable_pwnd_password?} %>
                   <%= render 'shared/fields/password_field', method: :password_confirmation %>
                 <% end %>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -14,7 +14,7 @@
 
        <div class="grid grid-cols-2 gap-5">
          <div>
-           <%= render 'shared/fields/password_field', form: f, method: :password, options: {show_strength_indicator: true} %>
+           <%= render 'shared/fields/password_field', form: f, method: :password, options: {show_strength_indicator: !disable_pwnd_password?} %>
          </div>
          <div>
            <%= render 'shared/fields/password_field', form: f, method: :password_confirmation, other_options: {error: f.object.errors.full_messages_for(:password).first, hide_custom_error: true} %>

--- a/lib/bullet_train.rb
+++ b/lib/bullet_train.rb
@@ -30,7 +30,7 @@ require "valid_email"
 require "commonmarker"
 require "extended_email_reply_parser"
 require "pagy"
-require "devise/pwned_password"
+require "devise/pwned_password" unless ENV["DISABLE_PWND_PASSWORD"]
 
 module BulletTrain
   mattr_accessor :routing_concerns, default: []

--- a/lib/bullet_train.rb
+++ b/lib/bullet_train.rb
@@ -133,3 +133,7 @@ end
 def silence_logs?
   ENV["SILENCE_LOGS"].present?
 end
+
+def disable_pwnd_password?
+  ENV["DISABLE_PWND_PASSWORD"].present?
+end


### PR DESCRIPTION
Context: https://discord.com/channels/836637622432170028/836637623048601633/1012396062050353152

## How to disable
Add the following to `config/application.yml` in your main Bullet Train application:
```yaml
DISABLE_PWND_PASSWORD: "true"
```

## Details

Most of the changes here are straightforward, but I decided to add this line because it will fire an `alert` otherwise even if we are able to save a weak password to the database without issues
```ruby
require "devise/pwned_password" unless ENV["DISABLE_PWND_PASSWORD"]
```
The alert
![Screenshot from 2022-08-26 12-30-10](https://user-images.githubusercontent.com/10546292/186811995-f5f755f8-4ea8-48a2-a3f7-322604a6858e.png)

