### PR TITLE
Add Application Options docs

### DIFF
--- a/app/views/layouts/docs.html.erb
+++ b/app/views/layouts/docs.html.erb
@@ -140,6 +140,12 @@
                     <i class="fal fa-check ti ti-video-camera"></i>
                   <% end %>
                 <% end %>
+
+                <%= render 'account/shared/menu/item', url: 'docs/application-options.md', label: 'Application Options' do |p| %>
+                  <% p.content_for :icon do %>
+                    <i class="fal fa-gear ti ti-settings"></i>
+                  <% end %>
+                <% end %>
               <% end %>
 
               <%= render 'account/shared/menu/section', title: 'Accounts & Teams' do %>

--- a/docs/application-options.md
+++ b/docs/application-options.md
@@ -14,6 +14,7 @@ The helper methods below can also be directly invoked in your application if you
 | INVITATION_KEYS | String | `"ofr9h5h9ghzeodh, ofr9h5h9ghzeodi"` | `invitation_keys` `invitation_only?` |
 | FONTAWESOME_NPM_AUTH_TOKEN | String | `"your_font_awesome_token"` | `font_awesome?` |
 | SILENCE_LOGS | Boolean | `"true"` | `silence_logs?` |
+| TESTING_PROVISION_KEY | String | `"asdf123"` | N/A |
 
 | Option | Description |
 | --- | --- |
@@ -25,3 +26,4 @@ The helper methods below can also be directly invoked in your application if you
 | INVITATION_KEYS | See more [Invitation Only](/docs/invitation_only.md) for more information. |
 | FONTAWESOME_NPM_AUTH_TOKEN | Enables use of Font Awesome. |
 | SILENCE_LOGS | Silences Super Scaffolding logs. |
+| TESTING_PROVISION_KEY | Creates a test `Platform::Application` by accessing `/testing/provision?key=your_provision_key` |

--- a/docs/application-options.md
+++ b/docs/application-options.md
@@ -1,0 +1,27 @@
+# Application Options
+
+Bullet Train features a list of options available at your disposal to enable/disable functionalities that would otherwise take a significant amount of time to implement. Simply add any of the following environment variables to `config/application.yml` in your main Bullet Train application and restart your server for the options to apply.
+
+The helper methods below can also be directly invoked in your application if you wish to have parts of your code depend on the functionality in question.
+
+| Option | Type | Example | Helper Methods |
+| --- | --- | --- | --- |
+| HIDE_THINGS | Boolean | `"true"` | `scaffolding_things_disabled?` |
+| HIDE_EXAMPLES | Boolean | `"true"` | `scaffolding_things_disabled?` |
+| STRIPE_CLIENT_ID | String | `"your_stripe_client_id"` | `stripe_enabled?` |
+| CLOUDINARY_URL | String | `"cloudinary://your_cloudinary_token_here"` | `cloudinary_enabled?` |
+| TWO_FACTOR_ENCRYPTION_KEY | String | `"your_encryption_key"` | `two_factor_enabled_authentication?` |
+| INVITATION_KEYS | String | `"ofr9h5h9ghzeodh, ofr9h5h9ghzeodi"` | `invitation_keys` `invitation_only?` |
+| FONTAWESOME_NPM_AUTH_TOKEN | String | `"your_font_awesome_token"` | `font_awesome?` |
+| SILENCE_LOGS | Boolean | `"true"` | `silence_logs?` |
+
+| Option | Description |
+| --- | --- |
+| HIDE_THINGS | Hides Bullet Train demo models such as `CreativeConcept` and `TangibleThing`. |
+| HIDE_EXAMPLES | Hides base models such as `CreativeConcept` and `TangibleThing`.
+| STRIPE_CLIENT_ID | See [Bullet Train Billing for Stripe](/docs/billing/stripe.md) for more information and related environment variables. |
+| CLOUDINARY_URL | Enables use of Cloudinary for handling images. |
+| TWO_FACTOR_ENCRYPTION_KEY | Enables two-factor authentication through Devise. |
+| INVITATION_KEYS | See more [Invitation Only](/docs/invitation_only.md) for more information. |
+| FONTAWESOME_NPM_AUTH_TOKEN | Enables use of Font Awesome. |
+| SILENCE_LOGS | Silences Super Scaffolding logs. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@
  - [Database Seeds](/docs/seeds.md)
  - [Test Suite](/docs/testing.md)
  - [Point-and-Click Test Writing](https://github.com/bullet-train-co/magic_test) <i class="ti ti-new-window ml-2"></i>
+ - [Application Options](/docs/application-options.md)
 
 ## Accounts & Teams
  - [Authentication](/docs/authentication.md)


### PR DESCRIPTION
I thought it would be helpful if we had a list of the different environment variables available in case developers wanted to know what they can turn on/off without having to refer to the helper methods in `bullet_train-base`.

I don't think this covers everything, but I left out `DEMO` on purpose because it seems like we only have that available for the original repository.

Also, I split this into two tables because of our current styling. The excess text overflowed off to the right, so I just figured having another table for now would be easiest to manage until we change the style if need be.

![Screenshot from 2022-08-26 15-02-01](https://user-images.githubusercontent.com/10546292/186832903-5d2e620c-7607-48e4-8f58-457209ab2b23.png)

