### PR TITLE
Put OAuth sign up link outside of standard sign up form

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -22,9 +22,9 @@
        </div>
 
        <%= f.submit t('global.buttons.sign_up'), class: 'button full' %>
-
-       <%= render 'devise/shared/oauth', verb: 'Sign Up' %>
      <% end %>
+
+     <%= render 'devise/shared/oauth', verb: 'Sign Up' %>
    <% end %>
   <% end %>
 <% end %>


### PR DESCRIPTION
The OAuth link for signing in was outside of the standard form in `sessions#new` which wasn't a problem, but the OAuth link for signing <i>up</i> was <b>inside</b> the form for `registrations#new`, so I moved it outside similar to the `sessions#new` page.

## Before
![Google OAuth - Before](https://user-images.githubusercontent.com/10546292/187369081-aa497e07-598e-4657-b73c-8ab2f36459e3.png)

## After
![Google Auto - After](https://user-images.githubusercontent.com/10546292/187369121-a36bfaeb-497f-454f-9b7d-45b7d256c08f.png)
