### PR TITLE
Add error handling for unresolved partials, resolve partials with literal path strings

### DIFF
--- a/lib/bullet_train/resolver.rb
+++ b/lib/bullet_train/resolver.rb
@@ -139,7 +139,9 @@ module BulletTrain
       if @needle.match?(/\.html\.erb$/)
         partial_parts = @needle.split("/")
 
-        if partial_parts.size == 3
+        # TODO: We should probably just default to raising an error if the developer
+        # provides a literal partial string without the name of the package it's coming from.
+        if partial_parts.size <= 3
           # If the string looks something like "shared/attributes/_code.html.erb",
           # all we need to do is change it to "shared/attributes/code"
           partial_parts.last.gsub!(/(_)|(\.html\.erb)/, "")

--- a/lib/bullet_train/resolver.rb
+++ b/lib/bullet_train/resolver.rb
@@ -146,27 +146,25 @@ module BulletTrain
           # all we need to do is change it to "shared/attributes/code"
           partial_parts.last.gsub!(/(_)|(\.html\.erb)/, "")
           @needle = partial_parts.join("/")
-        else
+        elsif @needle.match?(/bullet_train-/)
           # If it's a full path, we need to make sure we're getting it from the right package.
-          unless @needle.match?(/bullet_train\-/)
-            puts "You passed the absolute path for a partial literal, but we couldn't find the package name in the string: #{@needle}".red
-            puts ""
-            puts "Check the string one more time to see if the package name is there."
-            puts "\ti.e.: bullet_train-base/app/views/layouts/devise.html.erb".blue
-            puts "If you're not sure what the package name is, run `bin/resolve --interactive`, follow the prompt, and pass the annotated path."
-            puts "\ti.e.: <!-- BEGIN /your/local/path/bullet_train-base/app/views/layouts/devise.html.erb -->".blue
-            exit
-          else
-            _, partial_view_package, partial_path_without_package = @needle.partition(/bullet_train\-[a-z|\-|_|0-9|\.]*/)
+          _, partial_view_package, partial_path_without_package = @needle.partition(/bullet_train-[a-z|\-_0-9.]*/)
 
-            # Pop off the version so we can call `bundle show` correctly.
-            # Also change `bullet_train-base` to `bullet_train`.
-            partial_view_package.gsub!(/[\-|\.|0-9]*$/, "")if partial_view_package.match?(/[\-|\.|0-9]*$/)
-            partial_view_package.gsub!("-base", "") if @needle.match(/base/)
+          # Pop off the version so we can call `bundle show` correctly.
+          # Also change `bullet_train-base` to `bullet_train`.
+          partial_view_package.gsub!(/[\-|.0-9]*$/, "") if partial_view_package.match?(/[\-|.0-9]*$/)
+          partial_view_package.gsub!("-base", "") if /base/.match?(@needle)
 
-            local_package_path = `bundle show #{partial_view_package}`.chomp
-            return local_package_path + partial_path_without_package
-          end
+          local_package_path = `bundle show #{partial_view_package}`.chomp
+          return local_package_path + partial_path_without_package
+        else
+          puts "You passed the absolute path for a partial literal, but we couldn't find the package name in the string: #{@needle}".red
+          puts ""
+          puts "Check the string one more time to see if the package name is there."
+          puts "\ti.e.: bullet_train-base/app/views/layouts/devise.html.erb".blue
+          puts "If you're not sure what the package name is, run `bin/resolve --interactive`, follow the prompt, and pass the annotated path."
+          puts "\ti.e.: <!-- BEGIN /your/local/path/bullet_train-base/app/views/layouts/devise.html.erb -->".blue
+          exit
         end
       end
 

--- a/lib/bullet_train/resolver.rb
+++ b/lib/bullet_train/resolver.rb
@@ -158,12 +158,14 @@ module BulletTrain
           local_package_path = `bundle show #{partial_view_package}`.chomp
           return local_package_path + partial_path_without_package
         else
-          puts "You passed the absolute path for a partial literal, but we couldn't find the package name in the string: #{@needle}".red
+          puts "You passed the absolute path for a partial literal, but we couldn't find the package name in the string:".red
+          puts "`#{@needle}`".red
           puts ""
           puts "Check the string one more time to see if the package name is there."
-          puts "\ti.e.: bullet_train-base/app/views/layouts/devise.html.erb".blue
+          puts "i.e.: bullet_train-base/app/views/layouts/devise.html.erb".blue
+          puts ""
           puts "If you're not sure what the package name is, run `bin/resolve --interactive`, follow the prompt, and pass the annotated path."
-          puts "\ti.e.: <!-- BEGIN /your/local/path/bullet_train-base/app/views/layouts/devise.html.erb -->".blue
+          puts "i.e.: <!-- BEGIN /your/local/path/bullet_train-base/app/views/layouts/devise.html.erb -->".blue
           exit
         end
       end

--- a/lib/bullet_train/resolver.rb
+++ b/lib/bullet_train/resolver.rb
@@ -87,6 +87,18 @@ module BulletTrain
       }
 
       result[:absolute_path] = file_path || class_path || partial_path || locale_path
+
+      # If we get the partial resolver template itself, that means we couldn't find the file.
+      if result[:absolute_path].match?("app/views/bullet_train/partial_resolver.html.erb")
+        puts "We could not find the partial you're looking for: #{@needle}".red
+        puts ""
+        puts "Please try passing the partial string using either of the following two ways:"
+        puts "1. Without underscore and extention: ".blue + "bin/resolve shared/attributes/code"
+        puts "2. Literal path with package name: ".blue + "bin/resolve bullet_train-themes/app/views/themes/base/attributes/_code.html.erb"
+        puts ""
+        exit
+      end
+
       if result[:absolute_path]
         if result[:absolute_path].include?("/bullet_train")
           base_path = "bullet_train" + result[:absolute_path].partition("/bullet_train").last


### PR DESCRIPTION
Closes #114.

## Error handling for unresolved partials
Whenever the partial resolver couldn't find the file passed by the developer, we would just get the partial resolver template itself:
```
app/views/bullet_train/partial_resolver.html.erb
```

Instead of just returning this string, I typed out a message telling the developer to make sure they have the package name in the string to help us resolve it for them, or they could use the `--interactive` flag and pass the annotated path (in case they weren't aware of it already).

## Resolve partials with literal path strings
With that being said, if the developer passes the entire path starting from the package name, we can grab the package with the bundler so I added this feature to the script:
```
> bin/resolve bullet_train-themes-1.0.23/app/views/themes/base/attributes/_code.html.erb

Absolute path:
  /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bullet_train-themes-1.0.23/app/views/themes/base/attributes/_code.html.erb

Package name:
  bullet_train-themes-1.0.23
```

However, if it's something short like `shared/attributes/_code.html.erb`, then the script changes the string to `shared/attributes/code` and defaults to the behavior we already had in place for resolving the partial:

```
> bin/resolve shared/attributes/_code.html.erb

Absolute path:
  /home/gazayas/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/bullet_train-themes-1.0.23/app/views/themes/base/attributes/_code.html.erb

Package name:
  bullet_train-themes-1.0.23
```

## Resolving shorthand partials
I added a TODO here because I set up things to resolve the shorthand string if it's made up of 3 parts or less, i.e.:
```
shared/attributes/code
OR
shared/box
```
I'm thinking we should have another way of determining these though. Should we flag them if they start with `shared`? Any other strings? I'm not sure about this part, but at I least wrote the TODO in case we need to handle it sooner than later.