### PR TITLE
Add locale for default `Date` and `DateTime`

### DIFF
--- a/app/helpers/account/dates_helper.rb
+++ b/app/helpers/account/dates_helper.rb
@@ -14,10 +14,8 @@ module Account::DatesHelper
   # e.g. October 11, 2018 at 4:22 PM
   # e.g. Yesterday at 2:12 PM
   # e.g. April 24 at 7:39 AM
-  def display_date_and_time(timestamp, custom_date_format = nil, custom_time_format = nil, default_message = nil)
-    unless timestamp.present?
-      return default_message.present? default_message : t('.timestamp_unavailable')
-    end
+  def display_date_and_time(timestamp, custom_date_format = nil, custom_time_format = nil)
+    return nil unless timestamp
 
     # today?
     if local_time(timestamp).to_date == local_time(Time.now).to_date

--- a/app/helpers/account/dates_helper.rb
+++ b/app/helpers/account/dates_helper.rb
@@ -14,8 +14,10 @@ module Account::DatesHelper
   # e.g. October 11, 2018 at 4:22 PM
   # e.g. Yesterday at 2:12 PM
   # e.g. April 24 at 7:39 AM
-  def display_date_and_time(timestamp, custom_date_format = nil, custom_time_format = nil)
-    return nil unless timestamp
+  def display_date_and_time(timestamp, custom_date_format = nil, custom_time_format = nil, default_message = nil)
+    unless timestamp.present?
+      return default_message.present? default_message : t('.timestamp_unavailable')
+    end
 
     # today?
     if local_time(timestamp).to_date == local_time(Time.now).to_date

--- a/config/locales/en/base.yml
+++ b/config/locales/en/base.yml
@@ -77,6 +77,7 @@ en:
         one: Last Day
         other: Last %{count} Days
     formats:
+      timestamp_unavailable: Never
       date: '%m/%d/%Y'
       date_and_time: '%m/%d/%Y %l:%M %p'
 


### PR DESCRIPTION
Joint PRs
- https://github.com/bullet-train-co/bullet_train-api/pull/29
- https://github.com/bullet-train-co/bullet_train-themes/pull/20

Before, if an object's `Date` or `DateTime` was `nil`, we wouldn't display anything. This adds a locale so we can show a default message instead.

When rendering the partial, we can pass a local called `default_message` to use a message of our own instead of `Never`:
```ruby
<%= render 'shared/attributes/date_and_time', attribute: :last_used_at, default_message: t('custom_message') %>
```