### PR TITLE
Strong Params: Call strong params from respective API modules

### DIFF
--- a/app/controllers/concerns/account/controllers/base.rb
+++ b/app/controllers/concerns/account/controllers/base.rb
@@ -26,6 +26,10 @@ module Account::Controllers::Base
     def regex_to_remove_controller_namespace
       /^Account::/
     end
+
+    def strong_parameters_from_api
+      (name.gsub(regex_to_remove_controller_namespace, "Api::#{BulletTrain::Api.current_version.upcase}::") + "::StrongParameters").constantize
+    end
   end
 
   def adding_user_email?

--- a/app/controllers/concerns/account/controllers/base.rb
+++ b/app/controllers/concerns/account/controllers/base.rb
@@ -3,7 +3,7 @@ module Account::Controllers::Base
 
   included do
     include LoadsAndAuthorizesResource
-    include Fields::ControllerSupport
+    extend Fields::ControllerSupport
 
     if billing_enabled?
       include Billing::ControllerSupport
@@ -26,10 +26,12 @@ module Account::Controllers::Base
     def regex_to_remove_controller_namespace
       /^Account::/
     end
+  end
 
-    def strong_parameters_from_api
-      (name.gsub(regex_to_remove_controller_namespace, "Api::#{BulletTrain::Api.current_version.upcase}::") + "::StrongParameters").constantize
-    end
+  def strong_parameters_from_api
+    api_module = (self.class.to_s.gsub(/^Account::/, "Api::#{BulletTrain::Api.current_version.upcase}::") + "::StrongParameters").constantize
+    params_method = params["controller"].split("/").last.singularize + "_params"
+    api_module.send(params_method.to_sym, params, permitted_fields, permitted_arrays)
   end
 
   def adding_user_email?

--- a/app/controllers/concerns/account/teams/controller_base.rb
+++ b/app/controllers/concerns/account/teams/controller_base.rb
@@ -115,6 +115,12 @@ module Account::Teams::ControllerBase
 
   private
 
+  # Although our strong params are being filtered via strong_parameters_from_api,
+  # Rails still requires us to invoke this method in the controller.
+  # Otherwise we will get an ActiveModel::ForbiddenAttributes error.
+  def team_params
+  end
+
   def permitted_fields
     raise "It looks like you've removed `permitted_fields` from your controller. This will break Super Scaffolding."
   end

--- a/app/controllers/concerns/account/teams/controller_base.rb
+++ b/app/controllers/concerns/account/teams/controller_base.rb
@@ -19,9 +19,7 @@ module Account::Teams::ControllerBase
       @child_object = @team
     end
 
-    private
-
-    include strong_parameters_from_api
+    private_class_method :strong_parameters_from_api
   end
 
   # GET /teams

--- a/app/controllers/concerns/account/teams/controller_base.rb
+++ b/app/controllers/concerns/account/teams/controller_base.rb
@@ -19,7 +19,7 @@ module Account::Teams::ControllerBase
       @child_object = @team
     end
 
-    private_class_method :strong_parameters_from_api
+    private :strong_parameters_from_api
   end
 
   # GET /teams
@@ -68,7 +68,7 @@ module Account::Teams::ControllerBase
   # POST /teams
   # POST /teams.json
   def create
-    @team = Team.new(team_params)
+    @team = Team.new(strong_parameters_from_api)
 
     respond_to do |format|
       if @team.save
@@ -93,7 +93,7 @@ module Account::Teams::ControllerBase
   # PATCH/PUT /teams/1.json
   def update
     respond_to do |format|
-      if @team.update(team_params)
+      if @team.update(strong_parameters_from_api)
         format.html { redirect_to [:account, @team], notice: I18n.t("teams.notifications.updated") }
         format.json { render :show, status: :ok, location: [:account, @team] }
       else

--- a/app/controllers/concerns/controllers/base.rb
+++ b/app/controllers/concerns/controllers/base.rb
@@ -39,6 +39,15 @@ module Controllers::Base
     end
   end
 
+  class_methods do
+    # this is a template method called by LoadsAndAuthorizesResource.
+    # it allows that module to understand what namespaces of a controller
+    # are organizing the controllers, and which are organizing the models.
+    def regex_to_remove_controller_namespace
+      /^Account::/
+    end
+  end
+
   # this is an ugly hack, but it's what is recommended at
   # https://github.com/plataformatec/devise/wiki/How-To:-Create-custom-layouts
   def layout_by_resource
@@ -133,5 +142,13 @@ module Controllers::Base
       format.html(&block)
       format.json { render "#{params[:controller].gsub(/^account\//, "api/#{BulletTrain::Api.current_version}/")}/#{params[:action]}" }
     end
+  end
+
+  private
+
+  # Although our strong params are being filtered via strong_parameters_from_api,
+  # Rails still requires us to invoke this method in the controller.
+  # Otherwise we will get an ActiveModel::ForbiddenAttributes error.
+  def team_params
   end
 end

--- a/app/controllers/concerns/controllers/base.rb
+++ b/app/controllers/concerns/controllers/base.rb
@@ -39,12 +39,6 @@ module Controllers::Base
     end
   end
 
-  class_methods do
-    def strong_parameters_from_api
-      (name.gsub(regex_to_remove_controller_namespace, "Api::#{BulletTrain::Api.current_version.upcase}::") + "::StrongParameters").constantize
-    end
-  end
-
   # this is an ugly hack, but it's what is recommended at
   # https://github.com/plataformatec/devise/wiki/How-To:-Create-custom-layouts
   def layout_by_resource

--- a/app/controllers/concerns/controllers/base.rb
+++ b/app/controllers/concerns/controllers/base.rb
@@ -143,12 +143,4 @@ module Controllers::Base
       format.json { render "#{params[:controller].gsub(/^account\//, "api/#{BulletTrain::Api.current_version}/")}/#{params[:action]}" }
     end
   end
-
-  private
-
-  # Although our strong params are being filtered via strong_parameters_from_api,
-  # Rails still requires us to invoke this method in the controller.
-  # Otherwise we will get an ActiveModel::ForbiddenAttributes error.
-  def team_params
-  end
 end


### PR DESCRIPTION
## Testing
The tests pass on the starter repo as of now. There are a lot of joint PRs, so I'll add the branches here:

```ruby
gem "bullet_train", git: "git@github.com:bullet-train-co/bullet_train-base.git", branch: "fixes/strong-params-method"
gem "bullet_train-super_scaffolding", git: "git@github.com:bullet-train-co/bullet_train-super_scaffolding.git", branch: "fixes/strong-params-method"
gem "bullet_train-api", git: "git@github.com:bullet-train-co/bullet_train-api.git", branch: "fixes/strong-params-method"
gem "bullet_train-outgoing_webhooks", git: "git@github.com:bullet-train-co/bullet_train-outgoing_webhooks.git", branch: "fixes/strong-params-method"
gem "bullet_train-fields", git: "git@github.com:bullet-train-co/bullet_train-fields.git", branch: "fixes/strong-params-method"
```

## Details
I know there's a lot going on here, so I'll try to be as succinct as possible.

The way were including `strong_parameters_from_api` was an issue, so I ended up including the module which housed that method and made it private with `private :strong_parameters_from_api` as opposed to writing `include strong_parameters_from_api`. After that, there ended up being a number of other things that needed to be adjusted to make things work correctly.

For example, in `bullet_train-api` we had the following:

```ruby
module StrongParameters
  # Only allow a list of trusted parameters through.
  def team_params
    strong_params = params.require(:team).permit(
      *permitted_fields,
      :name,
      :time_zone,
      :locale,
      # 🚅 super scaffolding will insert new fields above this line.
      *permitted_arrays,
      # 🚅 super scaffolding will insert new arrays above this line.
    )

    process_params(strong_params)

    strong_params
  end
end
```

Although the method `strong_parameters_from_api` had access to `params`, `permitted_fields`, and `permitted_arrays`, those variables weren't available in the scope of this module, so I passed them as arguments as you can see in the joint `bullet_train-api` PR.

As pointed out in https://github.com/bullet-train-co/bullet_train-super_scaffolding/issues/75, the tests here in `bullet_train-base` were failing; the local tests are passing now, so we should be fine. The reason why we're still getting the `include strong_parameters_from_api` error in the other joint PRs is because those tests are still running with the main version of `bullet_train-base` and not this branch.

## Trouble including `Fields::ControllerSupport`
`Account::ApplicationController` includes `Fields::ControllerSupport` so although the helper methods are being included in the TangibleThings controller in `bullet_train-super_scaffold`, it's not being included in the Collaborators controller as well as the outgoing webhooks controller. I went ahead and included them directly and added a TODO so we can keep it on our radar.

## Standard Ruby
My brain's kind of fried right now, so I'll try to apply the Standard Ruby fixes tomorrow. That'll give me some time to mull over these PRs as a whole too.