### PR TITLE
Update the themes docs

### DIFF
--- a/docs/themes.md
+++ b/docs/themes.md
@@ -1,27 +1,21 @@
 # Themes
 
-Bullet Train has a theme subsystem designed to allow you the flexibility to either extend or completely replace the stock “Light” and “Clean” UI templates.
+Bullet Train has a theme subsystem designed to allow you the flexibility to either extend or completely replace the stock “Light” UI template.
+To reduce duplication of code across themes, Bullet Train implements the following three packages:
+1. `bullet_train-themes`
+2. `bullet_train-themes-tailwind_css`
+3. `bullet_train-themes-light`
 
-## Inheritance Structure
+This is where all of Bullet Train's standard views are contained.
 
-To reduce duplication of code across themes, Bullet Train implements an inheritance structure. For example, the official Bullet Train themes are structured hierarchically like so:
+## Adding a New Theme (ejecting standard views)
 
-- “Base”
-  - “Bootstrap” (in the future)
-    - “Clean” (in the future)
-  - “Tailwind CSS”
-    - “Light”
+If you want to add a new theme, you can use the following command. This will copy all of the standard views from `bullet_train-themes-light` to `app/views/themes/` and configure your application to use the new theme. For example, let's make a new theme called "foo":
+`> rake bullet_train:themes:light:eject[foo]`
 
-Any component partials that can be shared are pushed up the inheritance structure. For example, [Bullet Train's library of field partials](/docs/field-partials.md) provide a good example of this, illustrating the power of the approach we’ve taken here:
+After running this command, you will see that a few other files are edited to use this new theme. Whenever switching a theme, you will need to make the same changes to make sure your application is running with the theme of your choice.
 
- - The most general field styling varies substantially between Tailwind CSS and Bootstrap, so a `_field.html.erb` component partial exists in both the foundational “Tailwind CSS” and “Bootstrap” themes, but also a further customized version exists in themes like “Light”.
- - However, many concrete field types like `_text_field.html.erb` and `_phone_field.html.erb` leverage `_field.html.erb`, and they themselves are completely framework agnostic as a result. These partials can live in the shared “Base” theme.
-
-At run-time, this means:
-
-- When rendering `_text_field.html.erb`, it renders from “Base”.
-- However, when `_text_field.html.erb` references `_field.html.erb`, that renders from “Light”.
-- If you extend “Light” and override `_field.html.erb`, rendering `_text_field.html.erb` will now use your theme’s `_field.html.erb`.
+You can also pass an annotated path to a view after running `bin/resolve` to eject individual views to your application.
 
 ## Theme Component Usage
 
@@ -35,32 +29,11 @@ We say "within" because while a `shared` view partial directory does exist, the 
 
 ### Dealing with Indirection
 
-This small piece of indirection buys us an incredible amount of power in building and extending themes, but as with any indirection, it could potentially come at the cost of developer experience. That's why Bullet Train includes additional tools for smoothing over this experience. Be sure to read the section on [dealing with indirection].
-
+This small piece of indirection buys us an incredible amount of power in building and extending themes, but as with any indirection, it could potentially come at the cost of developer experience. That's why Bullet Train includes additional tools for smoothing over this experience. Be sure to read the section on [dealing with indirection](./indirection.md).
 
 ## Theme Configuration
 
-You can specify the theme you’d like to use and its inheritance structure in `app/helpers/theme_helper.rb`. The code there is well commented to help you.
-
-## Theme Structure
-
-Themes are represented in a few places. Taking “Light” as an example, we have:
-
-- A directory of theme-specific component partials in `app/views/themes/light`, including a layout ERB template.
-- A theme-specific stylesheet in `app/javascript/stylesheets/light/application.scss`.
-- A theme-specific pack in `app/javascript/packs/light.js`. You’ll see there that the actual JavaScript dependencies and code are shared across all themes. The whole purpose of this theme-specific pack is to serve up the theme-specific stylesheet.
-- Theme-specific logos and images in `app/javascript/images/light`.
-
-## Adding a New Theme
-
-To extend the “Light” theme in a new theme called “Tokyo”, we would:
-
-1. Copy `app/javascript/packs/light.js` to `app/javascript/packs/tokyo.js` and update references to `light` therein to `tokyo`.
-2. Copy `app/views/themes/light/layouts` to `app/views/themes/tokyo/layouts` and update references to `light` in the contained files to `tokyo`. It's possible this is too much duplication, but in practice most people want to customize these two layouts in their custom themes.
-3. Create a new file at `app/javascript/stylesheets/tokyo/application.scss`. To start just add `@import "../light/application";` at the top, which represents the fact that “Tokyo” extends “Light”. Any custom styles can be added below that.
-4. Add `"tokyo"` as the first item in the `THEME_DIRECTORY_ORDER` array in `app/helpers/theme_helper.rb`.
-
-You should be good to go! We'll try to add a generator for this in the future.
+Your application will automatically be configured to use your new theme whenever you run the eject command. Run `> rake bullet_train:themes:light:install` to re-install the standard light theme.
 
 ## Additional Guidance and Principles
 


### PR DESCRIPTION
I noticed our themes docs were outdated when someone asked me about `app/helpers/theme_helper.rb`. I'm sure there's more we could say here, but I at least wrote down the basics so our developers don't get confused when referring to the docs.

I could also see us writing a list of the different available components (like `shared/fields/text_field`) since we don't have a folder in the root directory for the developers to refer to.
