### PR TITLE
Use the `Current` model when retrieving the current team

### DIFF
--- a/app/helpers/account/teams_helper.rb
+++ b/app/helpers/account/teams_helper.rb
@@ -1,8 +1,11 @@
 module Account::TeamsHelper
   def current_team
-    # TODO We do not want this to be based on the `current_team_id`.
-    # TODO We want this to be based on the current resource being loaded.
-    current_user&.current_team
+    # load_team populates Current.team in LoadsAndAuthorizesResource.
+    controller.load_team
+
+    # controller.load_team unfortunately returns nil when the action is teams#index,
+    # so we fall back to using `current_user` here if @team or @current_team aren't available.
+    Current.team ||= controller.instance_variable_get(:@team) || controller.instance_variable_get(:@current_team) || current_user&.current_team
   end
 
   def other_teams


### PR DESCRIPTION
Address the TODO in `app/helpers/account/teams_helper.rb`

Joint PR
- https://github.com/bullet-train-co/bullet_train-super_load_and_authorize_resource/pull/1

## Details
I thought it would make the most sense to use `Current` if we want to keep track of the current team without directly referring to `current_user` and finding the current team from there, so I used `LoadsAndAuthorizesResource#load_team` which sets a value to `@team` if there isn't one already.

However, this didn't cover every case, so I fell back to `current_user&.current_team` when the action is `teams#index`.