### PR TITLE
Move `render_pagination` to `bullet_train-api`

### DIFF
--- a/app/helpers/concerns/helpers/base.rb
+++ b/app/helpers/concerns/helpers/base.rb
@@ -1,18 +1,10 @@
 module Helpers::Base
+  include Helpers::Api
   include Pagy::Frontend
   include Pagy::Backend
 
   def has_order?(scope)
     # This scope has an order if the SQL changes when we remove any order clause.
     scope.to_sql != scope.reorder("").to_sql
-  end
-
-  # TODO This should really be in the API package and included from there.
-  if defined?(BulletTrain::Api)
-    def render_pagination(json)
-      if @pagy
-        json.has_more @pagy.has_more
-      end
-    end
   end
 end

--- a/app/helpers/concerns/helpers/base.rb
+++ b/app/helpers/concerns/helpers/base.rb
@@ -1,5 +1,4 @@
 module Helpers::Base
-  include Helpers::Api
   include Pagy::Frontend
   include Pagy::Backend
 


### PR DESCRIPTION
Addresses the TODO in `app/helpers/concerns/helpers/base.rb`

Joint PR
- https://github.com/bullet-train-co/bullet_train-api/pull/33

This is the only other file I know that calls this method, and although the local tests pass I want to check the tests here too:
https://github.com/bullet-train-co/bullet_train-super_scaffolding/blob/39f5e6c78f3d1512d4cb097781f010e39ec9b120/app/views/api/v1/scaffolding/completely_concrete/tangible_things/index.json.jbuilder

I'll mark it as ready for review if everything's clear there.

Besides that, moving `to_json_api` wasn't so simple. If everything's clear here, I'll look more into moving that method as well.