### PR TITLE
Increase string performance in Records module

### DIFF
--- a/app/models/concerns/records/base.rb
+++ b/app/models/concerns/records/base.rb
@@ -84,7 +84,7 @@ module Records::Base
   if defined?(BulletTrain::Api)
     def to_api_json
       # TODO So many performance improvements available here.
-      controller = "Api::#{BulletTrain::Api.current_version.upcase}::ApplicationController".constantize.new
+      controller = "Api::V#{BulletTrain::Api.current_version_number}::ApplicationController".constantize.new
       # TODO We need to fix host names here.
       controller.request = ActionDispatch::Request.new({})
       local_class_key = self.class.name.underscore.split("/").last.to_sym


### PR DESCRIPTION
Addresses the TODO in `app/models/concerns/records/base.rb`

Joint PRs
- https://github.com/bullet-train-co/bullet_train/pull/457
- https://github.com/bullet-train-co/bullet_train-api/pull/34

## Details
I figured just grabbing and integer and removing the need to upcase something like "v1" would yield better performance results. I checked the performance with this following benchmark:

```ruby
require "test_helper"
require "benchmark"

class StringPerformanceTest
  Benchmark.bm 10 do |r|
    r.report "Old method" do
      "Api::#{BulletTrain::Api.current_version.upcase}::ApplicationController".constantize.new
    end

    r.report "New method" do
      "Api::V#{BulletTrain::Api.current_version_number}::ApplicationController".constantize.new
    end
  end
end
```

This resulted in over a 200% increase.
```
> bundle exec rails test test/benchmark/string_performance_test.rb
🌱 Generating global seeds.
                 user     system      total        real
Old method   0.005046   0.000000   0.005046 (  0.004847)
New method   0.000018   0.000000   0.000018 (  0.000017)
Run options: --seed 17147

# Running:



Finished in 0.004841s, 0.0000 runs/s, 0.0000 assertions/s.
0 runs, 0 assertions, 0 failures, 0 errors, 0 skips

```

## Other performance increases
I haven't removed the TODO because I figured there might be more areas to increase performance here, but nothing has come to mind so I left it as is.