### PR TITLE
Clone from matching branch in starter repo in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@0.1.2
   browser-tools: circleci/browser-tools@1.1
+  jq: circleci/jq@2.2.0
 aliases:
   - &restore_bundler_cache
       name: Restore Bundler cache
@@ -116,7 +117,9 @@ jobs:
     steps:
       - browser-tools/install-browser-tools
       - checkout
-      - run: "git clone https://github.com/bullet-train-co/bullet_train.git tmp/starter"
+      - run:
+          name: Clone Starter Repository for testing
+          command: bash ./.circleci/matching_branch_check
 
       - run:
           name: Rename the directory of the Ruby gem being tested for the partial resolver test.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,9 @@ jobs:
     steps:
       - browser-tools/install-browser-tools
       - checkout
-      - run: "git clone https://github.com/bullet-train-co/bullet_train.git tmp/starter"
+      - run:
+          name: Clone Starter Repository for testing
+          command: bash ./.circleci/matching_branch_check
 
       - run:
           name: Link starter repository to the Ruby gem being tested.

--- a/.circleci/matching_branch_check
+++ b/.circleci/matching_branch_check
@@ -9,4 +9,5 @@ for BRANCH in $BRANCH_NAMES; do
   fi
 done
 
+echo "Cloning from ${STARTER_REPO_BRANCH}..."
 git clone -b $STARTER_REPO_BRANCH https://github.com/bullet-train-co/bullet_train.git tmp/starter

--- a/.circleci/matching_branch_check
+++ b/.circleci/matching_branch_check
@@ -1,15 +1,12 @@
 # Default to the main branch if we don't find a matching branch on the starter repository.
 STARTER_REPO_BRANCH="main"
-
 BRANCH_NAMES=$(curl -H "Accept: application.vnd.github+json" https://api.github.com/repos/bullet-train-co/bullet_train/branches | jq '.[].name')
 
-# Checking if this provides the proper branch
-echo $CIRCLE_BRANCH
-
-# TODO: Check if CIRCLE_PR_BRANCH equals the branch name
 for BRANCH in $BRANCH_NAMES; do
-  echo ${BRANCH}
+  if [ ${BRANCH} == $CIRCLE_BRANCH ]; then
+    STARTER_REPO_BRANCH=$BRANCH
+    break
+  fi
 done
 
-# TODO: If we can get the matching branch, add the flag here
-git clone https://github.com/bullet-train-co/bullet_train.git tmp/starter
+git clone -b $STARTER_REPO_BRANCH https://github.com/bullet-train-co/bullet_train.git tmp/starter

--- a/.circleci/matching_branch_check
+++ b/.circleci/matching_branch_check
@@ -1,0 +1,15 @@
+# Default to the main branch if we don't find a matching branch on the starter repository.
+STARTER_REPO_BRANCH="main"
+
+BRANCH_NAMES=$(curl -H "Accept: application.vnd.github+json" https://api.github.com/repos/bullet-train-co/bullet_train/branches | jq '.[].name')
+CIRCLE_PR_BRANCH=$(curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.head.ref')
+
+echo $CIRCLE_PR_BRANCH
+
+# TODO: Check if CIRCLE_PR_BRANCH equals the branch name
+for BRANCH in $BRANCH_NAMES; do
+  echo ${BRANCH}
+done
+
+# TODO: If we can get the matching branch, add the flag here
+git clone https://github.com/bullet-train-co/bullet_train.git tmp/starter

--- a/.circleci/matching_branch_check
+++ b/.circleci/matching_branch_check
@@ -1,6 +1,6 @@
 # Default to the main branch if we don't find a matching branch on the starter repository.
 STARTER_REPO_BRANCH="main"
-BRANCH_NAMES=$(curl -H "Accept: application.vnd.github+json" https://api.github.com/repos/bullet-train-co/bullet_train/branches | jq '.[].name')
+BRANCH_NAMES=$(curl -H "Accept: application.vnd.github+json" https://api.github.com/repos/$CIRCLE_USERNAME/bullet_train/branches | jq '.[].name')
 
 for BRANCH in $BRANCH_NAMES; do
   if [ ${BRANCH} == $CIRCLE_BRANCH ]; then

--- a/.circleci/matching_branch_check
+++ b/.circleci/matching_branch_check
@@ -1,6 +1,6 @@
 # Default to the main branch if we don't find a matching branch on the starter repository.
 STARTER_REPO_BRANCH="main"
-BRANCH_NAMES=$(curl -H "Accept: application.vnd.github+json" https://api.github.com/repos/$CIRCLE_USERNAME/bullet_train/branches | jq '.[].name')
+BRANCH_NAMES=$(curl -H "Accept: application.vnd.github+json" https://api.github.com/repos/$CIRCLE_USERNAME/bullet_train/branches | jq -r '.[].name')
 
 for BRANCH in $BRANCH_NAMES; do
   if [ ${BRANCH} == $CIRCLE_BRANCH ]; then

--- a/.circleci/matching_branch_check
+++ b/.circleci/matching_branch_check
@@ -10,4 +10,4 @@ for BRANCH in $BRANCH_NAMES; do
 done
 
 echo "Cloning from ${STARTER_REPO_BRANCH}..."
-git clone -b $STARTER_REPO_BRANCH https://github.com/bullet-train-co/bullet_train.git tmp/starter
+git clone -b $STARTER_REPO_BRANCH https://github.com/$CIRCLE_USERNAME/bullet_train.git tmp/starter

--- a/.circleci/matching_branch_check
+++ b/.circleci/matching_branch_check
@@ -2,9 +2,9 @@
 STARTER_REPO_BRANCH="main"
 
 BRANCH_NAMES=$(curl -H "Accept: application.vnd.github+json" https://api.github.com/repos/bullet-train-co/bullet_train/branches | jq '.[].name')
-CIRCLE_PR_BRANCH=$(curl -s https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/pulls/${CIRCLE_PR_NUMBER} | jq -r '.head.ref')
 
-echo $CIRCLE_PR_BRANCH
+# Checking if this provides the proper branch
+echo $CIRCLE_BRANCH
 
 # TODO: Check if CIRCLE_PR_BRANCH equals the branch name
 for BRANCH in $BRANCH_NAMES; do


### PR DESCRIPTION
Closes #135

This PR clones the starter repo from a matching branch if it exists. If not, the branch is pulled from the developer's `main` branch.

The only pitfall I can see with this is if the developer hasn't updated their `main` branch. We can definitely default to `bullet-train-co/bullet_train` if there's not matching branch, but I have it cloning from the developer's repository for now.

Either way, you can see that this works because the text added in https://github.com/bullet-train-co/bullet_train/pull/499 shows up in the unit tests here:
 
![Screenshot from 2022-11-05 11-39-44](https://user-images.githubusercontent.com/10546292/200097722-a40e5243-18e4-4887-ad11-3295b299e261.png)
