### PR TITLE
Create api.md to fix broken link in docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,3 @@
+# REST API
+
+> TODO This section needs to be written and should probably delegate a lot of details to the README of the [Bullet Train API repository](https://github.com/bullet-train-co/bullet_train-api).


### PR DESCRIPTION
The "REST API" link in the documentation is broken. Since docs/index.md references a missing docs/api.md file, I've created it containing placeholder text based on docs/webhooks/outgoing.md.