### PR TITLE
Raise error when BASE_URL isn't correctly configured

### DIFF
--- a/app/controllers/concerns/documentation_support.rb
+++ b/app/controllers/concerns/documentation_support.rb
@@ -4,7 +4,7 @@ module DocumentationSupport
   def docs
     target = params[:page].presence || "index"
     all_paths = ([Rails.root.to_s] + `bundle show --paths`.lines.map(&:chomp))
-    @path = all_paths.map { |path| path + "/docs/#{target}.md" }.detect { |path| File.exists?(path) }
+    @path = all_paths.map { |path| path + "/docs/#{target}.md" }.detect { |path| File.exist?(path) }
     render :docs, layout: "docs"
   end
 end

--- a/lib/bullet_train.rb
+++ b/lib/bullet_train.rb
@@ -53,8 +53,13 @@ def default_url_options_from_base_url
 
   # the name of this property doesn't match up.
   default_url_options[:protocol] = parsed_base_url.scheme
+  default_url_options.compact!
 
-  default_url_options.compact
+  if default_url_options.empty?
+    raise "ENV['BASE_URL'] has not been configured correctly. Please check your environment variables and try one more time."
+  end
+
+  default_url_options
 end
 
 def inbound_email_enabled?


### PR DESCRIPTION
Closes #138.

## Details
If we don't set a valid URL to `ENV['BASE_URL']`, the `default_url_options_from_base_url` method returns an empty hash so our `config/environment/` files don't receive the correct values.

Also, Render generates a Random value for `BASE_URL`, so our code doesn't raise the first error we already had present in the method. Instead of editing that if statement, I figured we could just check if the hash is empty at the end and raise an error since the host, etc. aren't present.
