### PR TITLE
Add `--link` and `--reset` flags to `bin/develop`

### DIFF
--- a/lib/tasks/bullet_train_tasks.rake
+++ b/lib/tasks/bullet_train_tasks.rake
@@ -82,6 +82,58 @@ namespace :bullet_train do
       puts ""
     end
 
+    # Process any flags that were passed.
+    if arguments[:all_options].present?
+      flags_with_values = []
+
+      arguments[:all_options].split(/\s+/).each do |option|
+        if option.match?(/^\-\-/)
+          flags_with_values << {flag: option.gsub(/^\-\-/, "").to_sym, values: []}
+        else
+          flags_with_values.last[:values] << option
+        end
+      end
+
+      if flags_with_values.any?
+        flags_with_values.each do |process|
+          if process[:flag] == :link || process[:flag] == :reset
+            packages = process[:values]
+
+            gemfile_lines = File.readlines("./Gemfile")
+            new_lines = gemfile_lines.map do |line|
+              packages.each do |package|
+                if line.match?(package)
+                  original_path, local_path =
+                    [
+                      "gem \"bullet_train#{"-" + package unless package == "base"}\"",
+                      "gem \"bullet_train#{"-" + package unless package == "base"}\", path: \"local/bullet_train-#{package}\""
+                    ]
+
+                  case process[:flag]
+                  when :link
+                    line.gsub!(original_path, local_path)
+                    puts "Setting local '#{package}' package to the Gemfile...".blue
+                    break
+                  when :reset
+                    line.gsub!(local_path, original_path)
+                    puts "Resetting '#{package}' package in the Gemfile...".blue
+                    break
+                  end
+                end
+              end
+
+              line
+            end
+
+            File.open("./Gemfile", "w+") {|file| file.write(new_lines.join)}
+            system 'bundle install'
+          end
+        end
+
+        exit
+      end
+    end
+
     framework_packages = I18n.t("framework_packages")
 
     puts "Which framework package do you want to work on?".blue

--- a/lib/tasks/bullet_train_tasks.rake
+++ b/lib/tasks/bullet_train_tasks.rake
@@ -103,11 +103,8 @@ namespace :bullet_train do
             new_lines = gemfile_lines.map do |line|
               packages.each do |package|
                 if line.match?(package)
-                  original_path, local_path =
-                    [
-                      "gem \"bullet_train#{"-" + package unless package == "base"}\"",
-                      "gem \"bullet_train#{"-" + package unless package == "base"}\", path: \"local/bullet_train-#{package}\""
-                    ]
+                  original_path = "gem \"bullet_train#{"-" + package unless package == "base"}\""
+                  local_path = "gem \"bullet_train#{"-" + package unless package == "base"}\", path: \"local/bullet_train-#{package}\""
 
                   case process[:flag]
                   when :link

--- a/lib/tasks/bullet_train_tasks.rake
+++ b/lib/tasks/bullet_train_tasks.rake
@@ -87,8 +87,8 @@ namespace :bullet_train do
       flags_with_values = []
 
       arguments[:all_options].split(/\s+/).each do |option|
-        if option.match?(/^\-\-/)
-          flags_with_values << {flag: option.gsub(/^\-\-/, "").to_sym, values: []}
+        if option.match?(/^--/)
+          flags_with_values << {flag: option.gsub(/^--/, "").to_sym, values: []}
         else
           flags_with_values.last[:values] << option
         end
@@ -125,8 +125,8 @@ namespace :bullet_train do
               line
             end
 
-            File.open("./Gemfile", "w+") {|file| file.write(new_lines.join)}
-            system 'bundle install'
+            File.write("./Gemfile", new_lines.join)
+            system "bundle install"
           end
         end
 


### PR DESCRIPTION
Closes #145

## Details
```
> bin/develop --link super_scaffolding api
```

Running this command will automatically setup a developer's local repositories for `bullet_train-super_scaffolding` and `bullet_train-api` if they have already cloned them via `bin/develop`

```
> bin/develop --reset super_scaffolding api
```

This will revert the Gemfile's changes back to its original state for the selected packages only, and will also run `bundle install`.

## `bullet_train-fields`
I haven't gotten to the Stimulus controllers yet like I mentioned in #145, but I'd like to look into it sometime soon.