### PR TITLE
Use `@team` when available in `current_team` helper

### DIFF
--- a/app/helpers/account/teams_helper.rb
+++ b/app/helpers/account/teams_helper.rb
@@ -2,7 +2,7 @@ module Account::TeamsHelper
   def current_team
     # TODO We do not want this to be based on the `current_team_id`.
     # TODO We want this to be based on the current resource being loaded.
-    current_user&.current_team
+    @team || current_user&.current_team
   end
 
   def other_teams


### PR DESCRIPTION
Addresses the TODO in `app/helpers/account/teams_helper.rb`

I found this one to be difficult because of the resources we have available. The only one that I could see making the most sense to include here was `@team`, and even then it's not available in all contexts (i.e. - it's `@teams` instead for the index action).

Here is another line that I considered using:
```ruby
@team || @child_object&.team || @parent_object&.team || current_user&.current_team
```

In this case we would prioritize the objects provided in the controller, but ultimately fall back on the `current_user` object if none of them are available.

In the meantime I've left the TODO comment as is in case we wanted to approach the issue in another way.